### PR TITLE
fix default font family in dev mode

### DIFF
--- a/src/calm.lisp
+++ b/src/calm.lisp
@@ -148,7 +148,7 @@
                                          ;; default font size
                                          (c:set-font-size *calm-default-font-size*)
                                          ;; default font face
-                                         (c:select-font-face *calm-default-font-family* :normal :normal)
+                                         (c:select-font-family *calm-default-font-family* :normal :normal)
                                          ;; default color
                                          (c:set-source-rgb 0 0 0)
                                          ;; default position


### PR DESCRIPTION
use `select-font-family` instead of
`select-font-face` to enable custom fonts
support in development environment, since
it utilize `fc-init-reinitialize`