### PR TITLE
upgrade CALM to 1.3.0

### DIFF
--- a/.github/workflows/calm.yml
+++ b/.github/workflows/calm.yml
@@ -118,7 +118,7 @@ jobs:
             *.dmg
 
   Windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3
@@ -274,7 +274,7 @@ jobs:
             *.dmg
   Circles-Windows:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3
@@ -439,7 +439,7 @@ jobs:
             *.dmg
   Fan-Windows:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3
@@ -603,7 +603,7 @@ jobs:
             *.dmg
   Mondrian-Windows:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3
@@ -794,7 +794,7 @@ jobs:
             *.dmg
   Meditator-Windows:
     needs: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/calm.yml
+++ b/.github/workflows/calm.yml
@@ -77,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     env:
       CI_MATRIX_OS: ${{ matrix.os }}
@@ -225,7 +225,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     env:
       CI_MATRIX_OS: ${{ matrix.os }}
@@ -256,7 +256,7 @@ jobs:
           ls -lah calm
           rm *.dmg
           export PATH=$PATH:$(pwd)/calm/
-          export APP_VERSION=1.2.0
+          export APP_VERSION=1.3.0
           export APP_ID=com.vitovan.circles
           export APP_NAME=Circles
           # switch dir, this is unnecessary if you are already at the same dir with canvas.lisp
@@ -390,7 +390,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     env:
       CI_MATRIX_OS: ${{ matrix.os }}
@@ -421,7 +421,7 @@ jobs:
           ls -lah calm
           rm *.dmg
           export PATH=$PATH:$(pwd)/calm/
-          export APP_VERSION=1.2.0
+          export APP_VERSION=1.3.0
           export APP_ID=com.vitovan.fan
           export APP_NAME=Fan
           # switch dir, this is unnecessary if you are already at the same dir with canvas.lisp
@@ -554,7 +554,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     env:
       CI_MATRIX_OS: ${{ matrix.os }}
@@ -585,7 +585,7 @@ jobs:
           ls -lah calm
           rm *.dmg
           export PATH=$PATH:$(pwd)/calm/
-          export APP_VERSION=1.2.0
+          export APP_VERSION=1.3.0
           export APP_ID=com.vitovan.mondrian
           export APP_NAME=Mondrian
           # switch dir, this is unnecessary if you are already at the same dir with canvas.lisp
@@ -737,7 +737,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     env:
       CI_MATRIX_OS: ${{ matrix.os }}
@@ -769,7 +769,7 @@ jobs:
           ls -lah calm
           rm *.dmg
           export PATH=$PATH:$(pwd)/calm/
-          export APP_VERSION=1.2.0
+          export APP_VERSION=1.3.0
           export APP_ID=com.vitovan.meditator
           export APP_NAME=Meditator
           # switch dir, this is unnecessary if you are already at the same dir with canvas.lisp

--- a/.github/workflows/sbcl.yml
+++ b/.github/workflows/sbcl.yml
@@ -32,6 +32,7 @@ jobs:
           # otherwise, it won't build
           curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-ubuntu-20.04.zip
           unzip install_root.zip
+          rm install_root.zip
           mv ./install_root ./sbcl
           export PATH=$(pwd)/sbcl/bin:$PATH
           # start building new sbcl

--- a/.github/workflows/sbcl.yml
+++ b/.github/workflows/sbcl.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -25,19 +25,26 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install build-essential -y
-          sudo apt install sbcl libzstd-dev -y
+          sudo apt install libzstd-dev -y
       - name: build
         run: |
+          # use custom built sbcl for grandpa ubuntu
+          # otherwise, it won't build
+          curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-ubuntu-20.04.zip
+          unzip install_root.zip
+          mv ./install_root ./sbcl
+          export PATH=$(pwd)/sbcl/bin:$PATH
+          # start building new sbcl
           set -x
-          curl -OL http://downloads.sourceforge.net/project/sbcl/sbcl/2.3.4/sbcl-2.3.4-source.tar.bz2
+          curl -OL http://downloads.sourceforge.net/project/sbcl/sbcl/2.4.7/sbcl-2.4.7-source.tar.bz2
           set +x
-          bzip2 -cd sbcl-2.3.4-source.tar.bz2 | tar xvf -
-          cd sbcl-2.3.4
-          sh make.sh --with-fancy --with-sb-core-compression
+          bzip2 -cd sbcl-2.4.7-source.tar.bz2 | tar xvf -
+          cd sbcl-2.4.7
+          sh make.sh --with-sb-thread --with-sb-core-compression
       - name: zip install_root
         run: |
           set -x
-          cd sbcl-2.3.4
+          cd sbcl-2.4.7
           export INSTALL_ROOT=$HOME/install_root
           sh install.sh
           cd ..
@@ -58,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -69,19 +76,23 @@ jobs:
       - name: install
         shell: bash
         run: |
-          brew install sbcl
+          brew update && brew install sbcl && brew fetch zstd && brew reinstall zstd
       - name: build
         run: |
+          # for newer version of homebrew, the location of files has changed
+          export CPATH=$(brew --prefix zstd)/include:/usr/local/include:$CPATH
+          export LIBRARY_PATH=$(brew --prefix zstd)/lib/:$LIBRARY_PATH
+          # start building
           set -x
-          curl -OL http://downloads.sourceforge.net/project/sbcl/sbcl/2.3.4/sbcl-2.3.4-source.tar.bz2
+          curl -OL http://downloads.sourceforge.net/project/sbcl/sbcl/2.4.7/sbcl-2.4.7-source.tar.bz2
           set +x
-          bzip2 -cd sbcl-2.3.4-source.tar.bz2 | tar xvf -
-          cd sbcl-2.3.4
-          sh make.sh --with-fancy --with-sb-core-compression
+          bzip2 -cd sbcl-2.4.7-source.tar.bz2 | tar xvf -
+          cd sbcl-2.4.7
+          sh make.sh --with-sb-thread --with-sb-core-compression
       - name: zip install_root
         run: |
           set -x
-          cd sbcl-2.3.4
+          cd sbcl-2.4.7
           export INSTALL_ROOT=$HOME/install_root
           sh install.sh
           cd ..
@@ -102,7 +113,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2019]
 
     defaults:
       run:
@@ -129,14 +140,14 @@ jobs:
         run: |
           wget http://prdownloads.sourceforge.net/sbcl/sbcl-2.2.7-x86-64-windows-binary.msi
           7z x sbcl-2.2.7-x86-64-windows-binary.msi -Osbcl-2.2.7-bin && rm sbcl-2.2.7-x86-64-windows-binary.msi
-          wget http://downloads.sourceforge.net/project/sbcl/sbcl/2.3.4/sbcl-2.3.4-source.tar.bz2
-          bzip2 -cd sbcl-2.3.4-source.tar.bz2 | tar xvf -
-          cd sbcl-2.3.4
-          PATH=$PATH:"../sbcl-2.2.7-bin/" SBCL_HOME="../sbcl-2.2.7-bin/" sh make.sh --xc-host='sbcl --lose-on-corruption --disable-ldb --disable-debugger' --with-fancy --with-sb-core-compression
+          wget http://downloads.sourceforge.net/project/sbcl/sbcl/2.4.7/sbcl-2.4.7-source.tar.bz2
+          bzip2 -cd sbcl-2.4.7-source.tar.bz2 | tar xvf -
+          cd sbcl-2.4.7
+          PATH=$PATH:"../sbcl-2.2.7-bin/" SBCL_HOME="../sbcl-2.2.7-bin/" sh make.sh --xc-host='sbcl --lose-on-corruption --disable-ldb --disable-debugger' --with-sb-thread --with-sb-core-compression
       - name: zip install_root
         run: |
           set -x
-          cd sbcl-2.3.4
+          cd sbcl-2.4.7
           export INSTALL_ROOT=$HOME/install_root
           sh install.sh
           cd ..

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ calm
 ## Examples
 
 <p align="center">
-    <a href="https://vitovan.com/calm/1.2.0/fan/calm.html"><img width="250" alt="Fan" src="./docs/examples/fan/canvas.png"></a>
-    <a href="https://vitovan.com/calm/1.2.0/mondrian/calm.html"><img width="250" alt="Mondrian" src="./docs/examples/mondrian/canvas.png"></a>
-    <a href="https://vitovan.com/calm/1.2.0/meditator/calm.html"><img width="250" alt="Meditator" src="./docs/examples/meditator/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/fan/calm.html"><img width="250" alt="Fan" src="./docs/examples/fan/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/mondrian/calm.html"><img width="250" alt="Mondrian" src="./docs/examples/mondrian/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/meditator/calm.html"><img width="250" alt="Meditator" src="./docs/examples/meditator/canvas.png"></a>
 </p>
 
-Source files and binaries for the above examples are [here](https://github.com/VitoVan/calm/tree/main/docs/examples) and [here](https://github.com/VitoVan/calm/releases/tag/1.2.0).
+Source files and binaries for the above examples are [here](https://github.com/VitoVan/calm/tree/main/docs/examples) and [here](https://github.com/VitoVan/calm/releases/tag/1.3.0).
 
 For more applications made with CALM, please check [Made with CALM](https://github.com/VitoVan/made-with-calm).
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -31,12 +31,12 @@ calm
 ## 例
 
 <p align="center">
-    <a href="https://vitovan.com/calm/1.2.0/fan/calm.html"><img width="250" alt="Fan" src="./docs/examples/fan/canvas.png"></a>
-    <a href="https://vitovan.com/calm/1.2.0/mondrian/calm.html"><img width="250" alt="Mondrian" src="./docs/examples/mondrian/canvas.png"></a>
-    <a href="https://vitovan.com/calm/1.2.0/meditator/calm.html"><img width="250" alt="Meditator" src="./docs/examples/meditator/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/fan/calm.html"><img width="250" alt="Fan" src="./docs/examples/fan/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/mondrian/calm.html"><img width="250" alt="Mondrian" src="./docs/examples/mondrian/canvas.png"></a>
+    <a href="https://vitovan.com/calm/1.3.0/meditator/calm.html"><img width="250" alt="Meditator" src="./docs/examples/meditator/canvas.png"></a>
 </p>
 
-上記の例のソースファイルとバイナリは[こちら](https://github.com/VitoVan/calm/tree/main/docs/examples)と[こちら](https://github.com/VitoVan/calm/releases/tag/1.2.0)です。
+上記の例のソースファイルとバイナリは[こちら](https://github.com/VitoVan/calm/tree/main/docs/examples)と[こちら](https://github.com/VitoVan/calm/releases/tag/1.3.0)です。
 
 CALM で作られた他のアプリケーションについては、[Made with CALM](https://github.com/VitoVan/made-with-calm) をご覧ください。
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -83,7 +83,7 @@ build_msys () {
     RCEDIT_LICENSE="./s/usr/windows/rcedit-LICENSE"
     if [ ! -f "$RCEDIT" ]; then
         set -x
-        curl -o "$RCEDIT" -L https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+        curl -o "$RCEDIT" -L https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe
         curl -o "$RCEDIT_LICENSE" -L https://raw.githubusercontent.com/electron/rcedit/master/LICENSE
         set +x
     fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,6 +18,7 @@ build_fedora () {
     ./calm s dev fedora deps.sh && \
         ./calm s dev fedora sbcl.sh && \
         ./calm s dev all quicklisp.sh && \
+        ./calm s dev all quicklisp-fix-old-packages.sh && \
         ./calm s dev all alive.sh && \
         ./calm s dev all copy-lib.sh && \
         ./calm s dev fedora config-lib.sh
@@ -53,6 +54,8 @@ build_darwin () {
     ./calm s dev darwin deps.sh && \
         ./calm s dev darwin sbcl.sh && \
         ./calm s dev all quicklisp.sh && \
+        ./calm s dev all quicklisp-fix-apple-silicon.sh && \
+        ./calm s dev all quicklisp-fix-old-packages.sh && \
         ./calm s dev all alive.sh && \
         ./calm s dev all copy-lib.sh && \
         ./calm s dev darwin config-lib.sh && \
@@ -70,6 +73,7 @@ build_msys () {
     ./calm s dev msys deps.sh && \
         ./calm s dev msys sbcl.sh && \
         ./calm s dev all quicklisp.sh && \
+        ./calm s dev all quicklisp-fix-old-packages.sh && \
         ./calm s dev all alive.sh && \
         ./calm s dev all copy-lib.sh && \
         ./calm s dev msys config-lib.sh

--- a/calm.asd
+++ b/calm.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem #:calm
   :description "CALM - Canvas Aided Lisp Magic"
-  :version "1.2.0"
+  :version "1.3.0"
   :author "Vito Van"
   :license "GNU General Public License, version 2"
   :depends-on (

--- a/docs/changelog.org
+++ b/docs/changelog.org
@@ -1,7 +1,13 @@
 * CALM
 ** 1.3.0
-- remove macos-11 support
-- add macos-14 support
+- upgrade SBCL to 2.4.7
+- add macos-14 (arm64) support
+- fix: weird Quicklisp + Windows + SBCL bug
+  https://groups.google.com/g/quicklisp/c/wrULkRePVE4/m/DZHc0qVhAQAJ
+- fix: weird Windows + plain old CMD bug
+  https://github.com/VitoVan/calm/issues/179
+- ci: add macos-14 binary release
+- ci: remove macos-11 binary release
 ** 1.2.0
 - add documents:
   - hacking_JA.md @eltociear

--- a/docs/changelog.org
+++ b/docs/changelog.org
@@ -1,4 +1,7 @@
 * CALM
+** 1.3.0
+- remove macos-11 support
+- add macos-14 support
 ** 1.2.0
 - add documents:
   - hacking_JA.md @eltociear

--- a/entry.lisp
+++ b/entry.lisp
@@ -2,6 +2,9 @@
 (let ((quicklisp-setup (probe-file "quicklisp/setup.lisp")))
   (when quicklisp-setup
     (load quicklisp-setup)))
+;; https://groups.google.com/g/quicklisp/c/wrULkRePVE4
+#+win32
+(quicklisp-client::make-system-index "quicklisp/local-projects/")
 ;; Load CALM
 #-calm
 (load "calm.asd")

--- a/s/dev/all/alive.sh
+++ b/s/dev/all/alive.sh
@@ -1,5 +1,5 @@
 echo "Downloading alive-lsp ..."
 if ! [ -d quicklisp/local-projects/alive-lsp ]; then
-    git clone --depth 1 --branch v0.2.0 https://github.com/nobody-famous/alive-lsp.git quicklisp/local-projects/alive-lsp
+    git clone --depth 1 --branch v0.2.7 https://github.com/nobody-famous/alive-lsp.git quicklisp/local-projects/alive-lsp
     ./calm sbcl --load ./s/dev/all/load-calm.lisp --load ./s/dev/all/install-alive.lisp
 fi

--- a/s/dev/all/load-calm.lisp
+++ b/s/dev/all/load-calm.lisp
@@ -1,6 +1,9 @@
 ;; the existence of this file is to avoid the tricky shitty escaping of quotation marks
 #-quicklisp
 (load "./quicklisp/setup.lisp")
+;; https://groups.google.com/g/quicklisp/c/wrULkRePVE4
+#+win32
+(quicklisp-client::make-system-index "./quicklisp/local-projects/")
 #-calm
 (load "./calm.asd")
 #-calm

--- a/s/dev/all/quicklisp-fix-apple-silicon.sh
+++ b/s/dev/all/quicklisp-fix-apple-silicon.sh
@@ -1,0 +1,46 @@
+# https://github.com/lispgames/cl-sdl2/issues/154#issuecomment-1280030566
+# this path is made on 2024-08-06
+# should be removed when the following PR merged:
+#   https://github.com/lispgames/cl-sdl2/pull/167
+#   https://github.com/lispgames/cl-sdl2-image/pull/11
+#   https://github.com/Failproofshark/cl-sdl2-ttf/pull/28
+# and this issue closed:
+#   https://github.com/lispgames/cl-sdl2-mixer/issues/12
+
+
+# Get the system architecture
+arch=$(uname -m)
+
+# Check if the architecture is arm64
+if [ "$arch" == "arm64" ]; then
+    echo "This macOS system is ARM64. Applying SDL2 patch"
+    cd ./quicklisp/local-projects
+
+    git clone https://github.com/cffi/cffi.git
+    cd cffi
+    git reset --hard 13f21d5272d56e759d64895f670b428a63a16f01
+    cd ..
+
+    git clone https://github.com/rpav/cl-autowrap.git
+    cd cl-autowrap
+    git reset --hard 4bba9e37b59cd191dea150a89aef7245a40b1c9d
+    cd ..
+
+    git clone https://github.com/ellisvelo/cl-sdl2.git
+    cd cl-sdl2
+    git reset --hard fe8a1638dcadae3ea1e5627897cad3aa99f95635
+    cd ..
+
+    git clone https://github.com/ellisvelo/cl-sdl2-mixer.git
+    cd cl-sdl2-mixer
+    git reset --hard 8e20cbc06ab61413bdd0183da1d02bbb52fd7332
+    cd ..
+
+    git clone https://github.com/ellisvelo/cl-sdl2-image.git
+    cd cl-sdl2-image
+    git reset --hard 8734b0e24de9ca390c9f763d9d7cd501546d17d4
+    cd ..
+else
+    echo "This macOS system is not ARM64. No need to apply patch."
+    exit 0
+fi

--- a/s/dev/all/quicklisp-fix-old-packages.sh
+++ b/s/dev/all/quicklisp-fix-old-packages.sh
@@ -1,0 +1,7 @@
+# these are waiting for the next (maybe) Quicklisp update
+cd ./quicklisp/local-projects
+
+git clone https://github.com/andy128k/cl-gobject-introspection.git
+cd cl-gobject-introspection
+git reset --hard 4908a84c16349929b309c50409815ff81fb9b3c4
+cd ..

--- a/s/dev/darwin/config-lib.sh
+++ b/s/dev/darwin/config-lib.sh
@@ -4,15 +4,15 @@ set -x
 echo "config all libraries (.dylib) ..."
 cd ./lib
 
-cp /usr/local/lib/libzstd.dylib ./
-cp /usr/local/lib/libpangocairo*.dylib ./
+cp $(brew --prefix)/lib/libzstd.dylib ./
+cp $(brew --prefix)/lib/libpangocairo*.dylib ./
 
 # copy all dependencies
 # this should be ran for many times until no more dylib need to be copied
 # loop 42 times to make sure every dependency's dependency's dependency's ... dependencies are all copied
 for i in {1..42}
 do
-    otool -L *.dylib | grep /usr/local | awk '{print $1}' | xargs -I _ cp -n _ .
+    otool -L *.dylib | grep $(brew --prefix) | awk '{print $1}' | xargs -I _ cp -n _ .
 done
 
 chmod +w *.dylib
@@ -28,7 +28,7 @@ for f in *.dylib; do install_name_tool -id @rpath/`basename $f` $f; done
 # make all of them load dependencies from the @rpath
 for f in *.dylib
 do
-    for p in $(otool -L $f | grep /usr/local | awk '{print $1}')
+    for p in $(otool -L $f | grep $(brew --prefix) | awk '{print $1}')
     do
         install_name_tool -change $p @rpath/`basename $p` $f
     done
@@ -61,4 +61,4 @@ ln -s libzstd.1.dylib libzstd.dylib
 ls -lah .
 
 # copy all typelibs
-cp -L -R /usr/local/lib/girepository-1.0/*.typelib ./
+cp -L -R $(brew --prefix)/lib/girepository-1.0/*.typelib ./

--- a/s/dev/darwin/config-lib.sh
+++ b/s/dev/darwin/config-lib.sh
@@ -13,6 +13,8 @@ cp $(brew --prefix)/lib/libpangocairo*.dylib ./
 for i in {1..42}
 do
     otool -L *.dylib | grep $(brew --prefix) | awk '{print $1}' | xargs -I _ cp -n _ .
+    # some fuckers had fucked up rpath, we need to consider that
+    otool -L *.dylib | grep "@rpath" | sed s,@rpath,"$(brew --prefix)/lib/", | awk '{print $1}' | xargs -I _ cp -n _ .
 done
 
 chmod +w *.dylib

--- a/s/dev/darwin/sbcl.sh
+++ b/s/dev/darwin/sbcl.sh
@@ -3,9 +3,11 @@ if ! [ -d sbcl ]; then
     if ! [ -f install_root.zip ]; then
         set -x
         if [[ -z "${CI_MATRIX_OS}" ]]; then
-            curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-macos-13.zip
+            macos_version=$(sw_vers -productVersion | cut -d. -f1)
+            echo "macOS version: $macos_version"
+            curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.4.7/install_root-macos-${macos_version}.zip
         else
-            curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-${CI_MATRIX_OS}.zip
+            curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.4.7/install_root-${CI_MATRIX_OS}.zip
         fi
         set +x
     fi

--- a/s/dev/fedora/sbcl.sh
+++ b/s/dev/fedora/sbcl.sh
@@ -2,7 +2,7 @@ echo "Install SBCL binary (with compression feature) ..."
 if ! [ -d sbcl ]; then
     if ! [ -f install_root.zip ]; then
         set -x
-        curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-ubuntu-20.04.zip
+        curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.4.7/install_root-ubuntu-20.04.zip
         set +x
     fi
     rm -rf ./install_root

--- a/s/dev/msys/sbcl.sh
+++ b/s/dev/msys/sbcl.sh
@@ -2,7 +2,7 @@ echo "Install SBCL binary (with compression feature) ..."
 if ! [ -d sbcl ]; then
     if ! [ -f install_root.zip ]; then
         set -x
-        curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.3.4/install_root-windows-2022.zip
+        curl -o install_root.zip -L https://github.com/VitoVan/calm/releases/download/sbcl-2.4.7/install_root-windows-2019.zip
         set +x
     fi
     rm -rf ./install_root

--- a/s/usr/all/panic.lisp
+++ b/s/usr/all/panic.lisp
@@ -5,7 +5,7 @@
 ;; version check won't work on JSCL, since the lack of ASDF
 ;;
 #-jscl
-(let ((required-version "1.2.0")
+(let ((required-version "1.3.0")
       (calm-version (slot-value (asdf:find-system 'calm) 'asdf:version)))
   (when (uiop:version< calm-version required-version)
     (format t

--- a/s/usr/windows/icon.lisp
+++ b/s/usr/windows/icon.lisp
@@ -6,7 +6,7 @@
 (defun set-icon (app-icon)
 
   (let ((rcedit-bin (merge-pathnames "s/usr/windows/rcedit.exe" *calm-env-calm-home*))
-        (rcedit-url "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe")
+        (rcedit-url "https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe")
         (old-sbcl (merge-pathnames "sbcl/bin/sbcl.exe" *calm-env-calm-home*))
         (new-sbcl (merge-pathnames "sbcl/bin/sbcl-with-icon.exe" *calm-env-calm-home*))
         (calm-no-console (merge-pathnames "calmNoConsole.exe" *calm-env-calm-home*)))

--- a/src/calm.c
+++ b/src/calm.c
@@ -159,9 +159,11 @@ const char *get_lib_env() {
   if (ori_lib_env == NULL) {
     ori_lib_env = "";
   }
-  char *lib_env = malloc(
-      (strlen(ori_lib_env) + strlen(lib_path) + strlen(path_separator) + 1) *
-      sizeof(char));
+  char *lib_env =
+      malloc((strlen(ori_lib_env) + strlen(lib_path) + strlen(path_separator) +
+              1024  // I don't know what I'm doing
+              ) *
+             sizeof(char));
   strcpy(lib_env, ori_lib_env);
 
 #if defined _WIN32


### PR DESCRIPTION
- upgrade SBCL to 2.4.7
- add macos-14 (arm64) support
- fix: weird Quicklisp + Windows + SBCL bug
  https://groups.google.com/g/quicklisp/c/wrULkRePVE4/m/DZHc0qVhAQAJ
- fix: weird Windows + plain old CMD bug
  https://github.com/VitoVan/calm/issues/179
- ci: add macos-14 binary release
- ci: remove macos-11 binary release