### PR TITLE
doc: improve the guide for running macos applications bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ For more applications made with CALM, please check [Made with CALM](https://gith
 
 3. Add the extracted directory into your PATH environment
 
-   for macOS, add `/path/to/Calm.app/Contents/MacOS/` instead
+   for macOS, add `/Applications/Calm.app/Contents/MacOS/` instead
 
-For macOS and Windows users, you need to be smarter than [Windows SmartScreen](https://duckduckgo.com/?q=how+to+bypass+smartscreen) or able to [tame macOS](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to use CALM. In case anything went wrong, here is an [Installation Guide](docs/installation.md).
+For macOS and Windows users, you need to be smarter than [Windows SmartScreen](https://www.google.com/search?q=how+to+get+around+windows+smartscreen) or able to [tame macOS](https://www.google.com/search?q=how+to+remove+quarantine+flags+in+macos) to use CALM. In case anything went wrong, here is an [Installation Guide](docs/installation.md).
 
 ### Run from Source
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -56,9 +56,9 @@ CALM で作られた他のアプリケーションについては、[Made with C
 
 3. 解凍したディレクトリを PATH 環境に追加する
 
-   macOS の場合は、代わりに `/path/to/Calm.app/Contents/MacOS/` を追加する
+   macOS の場合は、代わりに `/Applications/Calm.app/Contents/MacOS/` を追加する
 
-macOS と Windows ユーザーの場合、CALM を使うには [Windows SmartScreen](https://duckduckgo.com/?q=how+to+bypass+smartscreen) よりもスマートであるか、[macOS を飼いならす事](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)ができる必要があります。万が一何かあったときのために、ここに[インストールガイド](docs/installation_JA.md)があります。
+macOS と Windows ユーザーの場合、CALM を使うには [Windows SmartScreen](https://www.google.com/search?q=how+to+get+around+windows+smartscreen) よりもスマートであるか、[macOS を飼いならす事](https://www.google.com/search?q=how+to+remove+quarantine+flags+in+macos)ができる必要があります。万が一何かあったときのために、ここに[インストールガイド](docs/installation_JA.md)があります。
 
 ### ソースからの実行
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,15 +14,19 @@ Now let's set up the environment for the ease of use.
 - macOS
   1. Open the downloaded DMG file
 
-  2. Drage the .app to the Applications folder
+  2. Drag the .app to the Applications folder
 
-  3. Eject the DMG and run Calm.app
+  3. Trust me and de-quarantine Calm.app
+
+      ```bash
+      xattr -d com.apple.quarantine /Applications/Calm.app
+      ```
+
+  4. Eject the DMG and run Calm.app
 
      **It may take a while** for the first run.
 
-     > On macOS, it's very likely the system will stop you from running the software, since it's not verified by Apple. If you have problem to run it, please check [this](https://support.apple.com/HT202491).
-
-  4. Add command `calm` to the PATH environment
+  5. Add command `calm` to the PATH environment
 
       ```bash
       echo 'export PATH="/Applications/Calm.app/Contents/MacOS/:$PATH"'>> ~/.bashrc
@@ -42,7 +46,7 @@ Now let's set up the environment for the ease of use.
       > echo 'export PATH="/c/calm/:$PATH"' >> ~/.bashrc
       > ```
 
-     > On Windows, it's very likely the system will stop you from running the software, since it's not verified by Microsoft. If you have problem to run it, please [find a way to bypass SmartScreen](https://duckduckgo.com/?q=how+to+bypass+smartscreen).
+     > On Windows, it's very likely the system will stop you from running the software, since it's not verified by Microsoft. If you have problem to run it, please [find a way to bypass SmartScreen](https://www.google.com/search?q=how+to+get+around+windows+smartscreen).
 
 
 Now you are all set, enjoy.

--- a/docs/installation_JA.md
+++ b/docs/installation_JA.md
@@ -16,7 +16,7 @@
 
   2. .app をアプリケーションフォルダにドラッグします
 
-  3. Trust me and de-quarantine Calm.app
+  3. 私を信じて、Calm.appの隔離を解除してください。
 
       ```bash
       xattr -d com.apple.quarantine /Applications/Calm.app

--- a/docs/installation_JA.md
+++ b/docs/installation_JA.md
@@ -16,13 +16,17 @@
 
   2. .app をアプリケーションフォルダにドラッグします
 
-  3. DMG を取り出し、Calm.app を実行する
+  3. Trust me and de-quarantine Calm.app
+
+      ```bash
+      xattr -d com.apple.quarantine /Applications/Calm.app
+      ```
+
+  4. DMG を取り出し、Calm.app を実行する
 
      初回の実行には **時間がかかるかもしれません。**
 
-     > macOS の場合、Apple によって検証されていないため、システムによってソフトウェアの実行が停止される確率が非常に高いです。実行に問題がある場合は、[こちら](https://support.apple.com/HT202491)を確認してください。
-
-  4. コマンド `calm` を PATH 環境に追加する
+  5. コマンド `calm` を PATH 環境に追加する
 
       ```bash
       echo 'export PATH="/Applications/Calm.app/Contents/MacOS/:$PATH"'>> ~/.bashrc
@@ -42,7 +46,7 @@
       > echo 'export PATH="/c/calm/:$PATH"' >> ~/.bashrc
       > ```
 
-     > Windows の場合、マイクロソフト社によって検証されていないため、システムがソフトウェアの実行を停止する確率が非常に高いです。実行に問題がある場合は、[SmartScreen をバイパスする方法を見つけてください](https://duckduckgo.com/?q=how+to+bypass+smartscreen)。
+     > Windows の場合、マイクロソフト社によって検証されていないため、システムがソフトウェアの実行を停止する確率が非常に高いです。実行に問題がある場合は、[SmartScreen をバイパスする方法を見つけてください](https://www.google.com/search?q=how+to+bypass+smartscreen)。
 
 
 これで準備万端、お楽しみください。


### PR DESCRIPTION
mainly for macos-14, the right click method didn't work, it seems the user has to de-quarantine with command.

I changed the search links from duckduckgo to google,
for the search results of better relevance.