### PR TITLE
macos: codesign for new macos security limitation

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -45,6 +45,8 @@ build_darwin () {
     echo "build launcher ..."
     brew install gcc
     gcc src/calm.c -o calm
+    # codesign for macos-14 enhanced security
+    codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime calm
 
     echo "remove Windows fonts dir ..."
     sed '/<dir>C:\\Windows\\Fonts<\/dir>/d' s/usr/all/fonts.conf > tmp-fonts.conf

--- a/s/dev/darwin/config-lib.sh
+++ b/s/dev/darwin/config-lib.sh
@@ -65,5 +65,6 @@ ls -lah .
 # copy all typelibs
 cp -L -R $(brew --prefix)/lib/girepository-1.0/*.typelib ./
 
-# codesign for macos-14, since we changed those libs
+# codesign for macos-14 enhanced security
 ls *.dylib | xargs -I _ codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime _
+ls *.typelib | xargs -I _ sudo codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime _


### PR DESCRIPTION
Before this change:

1. CALM itself will be shown as a damaged application,
   the user has to de-quarantine it with command line:
   
   xattr -d com.apple.quarantine /Applications/Calm.app

2. CALM made applications, will also be shown as damaged,
   the user also has to de-quarantine them.

After this change:

1. CALM itself still be shown as a damaged application.

2. CALM made applications, will shown as:
   "cannot be opened because the developer cannot be verified."
   which is better, since the user could open it with right click.